### PR TITLE
principal star

### DIFF
--- a/doc_source/reference_policies_elements_principal.md
+++ b/doc_source/reference_policies_elements_principal.md
@@ -139,18 +139,12 @@ Some AWS services support additional options for specifying a principal\. For ex
 
 **Everyone \(anonymous users\)** 
 
-The following are equivalent:
-
-```
-"Principal": "*"
-```
-
 ```
 "Principal" : { "AWS" : "*" }
 ```
 
 **Note**  
-In these examples, the asterisk \(\*\) is used as a placeholder for Everyone/Anonymous\. You cannot use it as a wildcard to match part of a name or an ARN\. We also strongly recommend that you do not use a wildcard in the `Principal` element in a role's trust policy unless you otherwise restrict access through a `Condition` element in the policy\. Otherwise, any IAM user in any account can access the role\.
+In this example, the asterisk \(\*\) is used as a placeholder for Everyone/Anonymous\. You cannot use it as a wildcard to match part of a name or an ARN\. We also strongly recommend that you do not use a wildcard in the `Principal` element in a role's trust policy unless you otherwise restrict access through a `Condition` element in the policy\. Otherwise, any IAM user in any account can access the role\.
 
 ## More Information<a name="Principal_more-info"></a>
 


### PR DESCRIPTION
"Principal" : "*" doesn't work
Error Message:
An error occurred: AssumeRolepolicy contained an invalid principal: "STAR":"*".
Policy document:
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": "*",
      "Action": "sts:AssumeRole"
    }
  ]
}
you can reach out to me at reinherz@amazon.com

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
